### PR TITLE
Add possibility to update multiple domains with one update url

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,15 @@ Self-hosted dynamic DNS php script to update netcup DNS API from Router like AVM
 ### AVM FRITZ!Box Settings
 * Go to "Internet" -> "Freigaben" -> "DynDNS"
 * Choose "Benutzerdefiniert"
-* Update-URL: `https://<url of your webspace>/update.php?user=<username>&password=<pass>&ipv4=<ipaddr>&ipv6=<ip6addr>&domain=<domain>`
-  * only the url needs to be adjusted, the rest is automatically filled by your AVM FRITZ!Box
-  * http or https is possible if valid SSL certificate (e.g. Let's Encrypt)
+* Single Domain:
+  * Update-URL: `https://<url of your webspace>/update.php?user=<username>&password=<pass>&ipv4=<ipaddr>&ipv6=<ip6addr>&domain=<domain>`
+    * only the url needs to be adjusted, the rest is automatically filled by your AVM FRITZ!Box
+    * http or https is possible if valid SSL certificate (e.g. Let's Encrypt)
+* Multiple Domains
+  * To Update Multiple domains, add every domain as a comma seperated list.
+  * Update-URL: `https://<url of your webspace>/update.php?user=<username>&password=<pass>&ipv4=<ipaddr>&ipv6=<ip6addr>&domain=<domain1>,<domain2>,<domain3>....`
+    * only the url needs to be adjusted, the rest is automatically filled by your AVM FRITZ!Box
+    * http or https is possible if valid SSL certificate (e.g. Let's Encrypt)
 * Domainname: `<host record that is supposed to be updated>`
 * Username: `<username as defined in .env file>`
 * Password: `<password as definied in .env file>`

--- a/update.php
+++ b/update.php
@@ -17,4 +17,17 @@ if (!file_exists('.env')) {
 
 $config = parse_ini_file('.env', false, INI_SCANNER_TYPED);
 
-(new netcup\DNS\API\Handler($config, $_REQUEST))->doRun();
+// Get the domains from the URL parameter
+$domains = explode(',', $_REQUEST['domain']);
+
+// Loop through each domain and call the Handler
+foreach ($domains as $domain) {
+    // Create a new request object with the current domain
+    $request = $_REQUEST;
+    $request['domain'] = trim($domain);
+    // echo "Processing domain: {$domain}\n";
+
+
+    // Call the Handler with the current domain
+    (new netcup\DNS\API\Handler($config, $request))->doRun();
+}

--- a/update.php
+++ b/update.php
@@ -17,7 +17,7 @@ if (!file_exists('.env')) {
 
 $config = parse_ini_file('.env', false, INI_SCANNER_TYPED);
 
-// Get the domains from the URL parameter
+// Get the domains from the URL parameter and split them from the comma separated string
 $domains = explode(',', $_REQUEST['domain']);
 
 // Loop through each domain and call the Handler
@@ -25,7 +25,6 @@ foreach ($domains as $domain) {
     // Create a new request object with the current domain
     $request = $_REQUEST;
     $request['domain'] = trim($domain);
-    // echo "Processing domain: {$domain}\n";
 
 
     // Call the Handler with the current domain


### PR DESCRIPTION
This pull request provides the ability to update multiple domains with a single update URL. 

To update the domains pass the Domains as a comma seperated list:
````
https://<url of your webspace>/update.php?user=<username>&password=<pass>&ipv4=<ipaddr>&ipv6=<ip6addr>&domain=<domain1>,<domain2>,<domain3>,....
````

The "old" syntax for the update URL, with only one domain, still works too:
````
https://<url of your webspace>/update.php?user=<username>&password=<pass>&ipv4=<ipaddr>&ipv6=<ip6addr>&domain=<domain>
````