### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,13 @@ Self-hosted dynamic DNS php script to update netcup DNS API from Router like AVM
 ### AVM FRITZ!Box Settings
 * Go to "Internet" -> "Freigaben" -> "DynDNS"
 * Choose "Benutzerdefiniert"
+* Update-URL: `https://<url of your webspace>/update.php?user=<username>&password=<pass>&ipv4=<ipaddr>&ipv6=<ip6addr>&domain=<domain>`
+  * only the url needs to be adjusted, the rest is automatically filled by your AVM FRITZ!Box
+  * http or https is possible if valid SSL certificate (e.g. Let's Encrypt)
 * Single Domain:
-  * Update-URL: `https://<url of your webspace>/update.php?user=<username>&password=<pass>&ipv4=<ipaddr>&ipv6=<ip6addr>&domain=<domain>`
-    * only the url needs to be adjusted, the rest is automatically filled by your AVM FRITZ!Box
-    * http or https is possible if valid SSL certificate (e.g. Let's Encrypt)
-* Multiple Domains
-  * To Update Multiple domains, add every domain as a comma seperated list.
-  * Update-URL: `https://<url of your webspace>/update.php?user=<username>&password=<pass>&ipv4=<ipaddr>&ipv6=<ip6addr>&domain=<domain1>,<domain2>,<domain3>....`
-    * only the url needs to be adjusted, the rest is automatically filled by your AVM FRITZ!Box
-    * http or https is possible if valid SSL certificate (e.g. Let's Encrypt)
-* Domainname: `<host record that is supposed to be updated>`
+  * Domainname: `<host record that is supposed to be updated>`
+* Multiple Domains:
+  * Domainname: `<first host record that is supposed to be updated>,<second host record that is supposed to be updated>,....`
 * Username: `<username as defined in .env file>`
 * Password: `<password as definied in .env file>`
 


### PR DESCRIPTION
Fixed the Readme, to be compatible with the FRITZ!Box Settings.

Accidentally changed the Update URL, which must not be changed. In The FRITZ!Box only the "Domainname" must be handled differently. 

The Update URL in the FRITZ!Box stays the same.