### PR TITLE
feat: IPv6 prefix + suffix support for FRITZ!Box

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,14 @@ Self-hosted dynamic DNS php script to update netcup DNS API from Router like AVM
 ### AVM FRITZ!Box Settings
 * Go to "Internet" -> "Freigaben" -> "DynDNS"
 * Choose "Benutzerdefiniert"
-* Update-URL: `https://<url of your webspace>/update.php?user=<username>&password=<pass>&ipv4=<ipaddr>&ipv6=<ip6addr>&domain=<domain>`
+* Update-URL for the FRITZ!Box itself (IPv4 + IPv6): `https://<url of your webspace>/update.php?user=<username>&password=<pass>&ipv4=<ipaddr>&ipv6=<ip6addr>&domain=<domain>`
+* Update-URL for a device behind the FRITZ!Box (prefix + suffix, two URLs separated by space):
+  `https://<url of your webspace>/update.php?user=<username>&password=<pass>&domain=<domain>&mode=both&ipv4=<ipaddr> https://<url of your webspace>/update.php?user=<username>&password=<pass>&domain=<domain>&mode=both&ipv6=::1a2b:3c4d:5e6f:7890&ipv6prefix=<ip6lanprefix>&_ip6addr=<ip6addr>`
+  * The first URL updates the A record, the second updates the AAAA record
+  * When `ipv6prefix` is provided, the `ipv6` value is treated as suffix (interface ID) and combined with the prefix to form the full AAAA address
+  * `ipv6prefix` accepts a bare prefix (e.g. `2001:db8:abcd:ef00`), with trailing `::` (e.g. `2001:db8:abcd:ef00::`), or with CIDR notation (e.g. `2001:db8:abcd:ef00::/64` as sent by FRITZ!Box via `<ip6lanprefix>`)
+  * `_ip6addr=<ip6addr>` is required so the FRITZ!Box resolves the `<ip6lanprefix>` placeholder
+  * Replace `::1a2b:3c4d:5e6f:7890` with the static interface ID of your target device
   * only the url needs to be adjusted, the rest is automatically filled by your AVM FRITZ!Box
   * http or https is possible if valid SSL certificate (e.g. Let's Encrypt)
 * Single Domain:

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -142,14 +142,14 @@ final class Handler
                 }
 
                 // update AAAA Record if exists and IP has changed
-                if ('AAAA' === $record->type && $this->payload->getIpv6() &&
+                if ('AAAA' === $record->type && $this->payload->getResolvedIpv6() &&
                     (
                         $this->payload->isForce()
-                        || $record->destination !== $this->payload->getIpv6()
+                        || $record->destination !== $this->payload->getResolvedIpv6()
                     )
                 ) {
-                    $record->destination = $this->payload->getIpv6();
-                    $this->doLog(sprintf('IPv6 for %s set to %s', $record->hostname . '.' . $this->payload->getHostname(), $this->payload->getIpv6()));
+                    $record->destination = $this->payload->getResolvedIpv6();
+                    $this->doLog(sprintf('IPv6 for %s set to %s', $record->hostname . '.' . $this->payload->getHostname(), $this->payload->getResolvedIpv6()));
                     $changes = true;
                 }
             }

--- a/src/Payload.php
+++ b/src/Payload.php
@@ -35,6 +35,11 @@ final class Payload
     private $ipv6;
 
     /**
+     * @var string
+     */
+    private $ipv6prefix;
+
+    /**
      * @var bool
      */
     private $force = false;
@@ -57,6 +62,7 @@ final class Payload
             !empty($this->user) &&
             !empty($this->password) &&
             !empty($this->domain) &&
+            (!empty($this->ipv6prefix) ? $this->isValidIpv6Prefix() : true) &&
             (
                 (
                     !empty($this->ipv4) && $this->isValidIpv4()
@@ -166,6 +172,65 @@ final class Payload
     public function isValidIpv6()
     {
         return (bool)filter_var($this->ipv6, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6);
+    }
+
+    /**
+     * @return string
+     */
+    public function getIpv6Prefix()
+    {
+        return $this->ipv6prefix;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isValidIpv6Prefix()
+    {
+        $normalized = self::normalizePrefix($this->ipv6prefix);
+
+        return (bool)filter_var($normalized, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6);
+    }
+
+    /**
+     * Returns the full IPv6 address, combining prefix + suffix if ipv6prefix is set.
+     *
+     * @return string
+     */
+    public function getResolvedIpv6()
+    {
+        if (!empty($this->ipv6prefix)) {
+            return self::combineIpv6($this->ipv6prefix, $this->ipv6);
+        }
+
+        return $this->ipv6;
+    }
+
+    /**
+     * @return string
+     */
+    private static function normalizePrefix(string $prefix): string
+    {
+        // Strip CIDR notation (e.g. /64) sent by FRITZ!Box
+        $normalized = preg_replace('/\/\d+$/', '', $prefix);
+        $normalized = rtrim($normalized, ':');
+        if (strpos($normalized, '::') === false) {
+            $normalized .= '::';
+        }
+
+        return $normalized;
+    }
+
+    private static function combineIpv6(string $prefix, string $suffix): string
+    {
+        $prefixBin = inet_pton(self::normalizePrefix($prefix));
+        $suffixBin = inet_pton($suffix);
+
+        if ($prefixBin === false || $suffixBin === false) {
+            throw new \RuntimeException('Invalid IPv6 prefix or suffix');
+        }
+
+        return inet_ntop(substr($prefixBin, 0, 8) . substr($suffixBin, 8, 8));
     }
 
     /**


### PR DESCRIPTION
Closes #4

## Summary
- Adds optional `ipv6prefix` request parameter to support devices **behind** a FRITZ!Box router
- When `ipv6prefix` is provided, combines the dynamic ISP-assigned prefix (first 64 bits) with a static suffix/interface ID (last 64 bits) to produce the full AAAA record
- Without `ipv6prefix`, existing behavior is unchanged (`ipv6` used as a complete address)

## `ipv6prefix` format
The parameter accepts any of the following formats:
- Bare prefix: `2001:db8:abcd:ef00`
- With trailing `::`: `2001:db8:abcd:ef00::`
- With CIDR notation: `2001:db8:abcd:ef00::/64` (as sent by FRITZ!Box via `<ip6lanprefix>`)

All formats are normalized (CIDR stripped, `::` appended if needed) before validation and combination.

## Example
```
ipv6=::1a2b:3c4d:5e6f:7890&ipv6prefix=2001:db8:abcd:ef00::/64
→ AAAA: 2001:db8:abcd:ef00:1a2b:3c4d:5e6f:7890
```

## FRITZ!Box Update-URL (two URLs separated by space)
```
https://dyn.example.com/update.php?user=<username>&password=<pass>&domain=<domain>&mode=both&ipv4=<ipaddr> https://dyn.example.com/update.php?user=<username>&password=<pass>&domain=<domain>&mode=both&ipv6=::1a2b:3c4d:5e6f:7890&ipv6prefix=<ip6lanprefix>&_ip6addr=<ip6addr>
```

Note: `_ip6addr=<ip6addr>` is a dummy parameter (ignored by the script) required so the FRITZ!Box resolves the `<ip6lanprefix>` placeholder.

## Changes
- **`src/Payload.php`**: Added `$ipv6prefix` property, `getIpv6Prefix()`, `isValidIpv6Prefix()`, `getResolvedIpv6()`, `normalizePrefix()`, and `combineIpv6()`. Updated `isValid()` to reject invalid prefixes.
- **`src/Handler.php`**: AAAA record handling now uses `getResolvedIpv6()` instead of `getIpv6()`
- **`README.md`**: Documented the prefix+suffix Update-URL and accepted `ipv6prefix` formats